### PR TITLE
Upgrade dependencies for Vue 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
     "firebase": "^7.2.1",
     "moment": "^2.24.0",
     "vee-validate": "^3.3.7",
-    "vue": "^2.6.10",
-    "vue-router": "^3.1.3",
+    "vue": "^3.0.0",
+    "vue-router": "^4.0.0",
     "vuejs-dialog": "^1.4.1",
-    "vuetify": "^2.2.11",
-    "vuex": "^3.1.2"
+    "vuetify": "^3.0.0",
+    "vuex": "^4.0.0"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^4.0.0",
-    "@vue/cli-plugin-eslint": "^4.0.0",
-    "@vue/cli-service": "^4.0.0",
+    "@vue/cli-plugin-babel": "^5.0.0",
+    "@vue/cli-plugin-eslint": "^5.0.0",
+    "@vue/cli-service": "^5.0.0",
     "babel-eslint": "^10.0.3",
     "csv-parser": "^3.2.0",
     "eslint": "^5.16.0",
@@ -29,8 +29,8 @@
     "sass": "1.32.13",
     "sass-loader": "^8.0.0",
     "vue-cli-plugin-vuetify": "^2.0.6",
-    "vue-template-compiler": "^2.6.10",
-    "vuetify-loader": "^1.3.0",
+    "vuetify-loader": "^2.0.0",
+    "@vue/compiler-sfc": "^3.0.0",
     "yargs": "^17.7.2"
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,7 @@
-module.exports = {
-  "transpileDependencies": [
-    "vuetify"
+const { defineConfig } = require('@vue/cli-service')
+
+module.exports = defineConfig({
+  transpileDependencies: [
+    'vuetify'
   ]
-}
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -9362,13 +9362,6 @@ vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.6.10:
-  version "2.7.16"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz#c81b2d47753264c77ac03b9966a46637482bb03b"
-  integrity sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==
-  dependencies:
-    de-indent "^1.0.2"
-    he "^1.2.0"
 
 vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"


### PR DESCRIPTION
## Summary
- upgrade core tooling to Vue 3 ecosystem
- remove old vue-template-compiler lock entry
- refresh Vue CLI configuration for Vuetify 3

## Testing
- `yarn install` *(fails: RequestError tunneling socket could not be established)*
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6846e28dcd188333933ed177a08c3981